### PR TITLE
Fix package name typo that broke windows compilation

### DIFF
--- a/pkg/rtcconfig/rtc_windows.go
+++ b/pkg/rtcconfig/rtc_windows.go
@@ -1,7 +1,7 @@
 //go:build windows
 // +build windows
 
-package rtcconfg
+package rtcconfig
 
 func checkUDPReadBuffer() {
 }


### PR DESCRIPTION
closes #7 