### PR TITLE
Use redundant STUN requests to get external IP.

### DIFF
--- a/pkg/rtcconfig/config.go
+++ b/pkg/rtcconfig/config.go
@@ -35,6 +35,7 @@ const (
 var DefaultStunServers = []string{
 	"stun.l.google.com:19302",
 	"stun1.l.google.com:19302",
+	"global.stun.twilio.com:3478",
 }
 
 type RTCConfig struct {

--- a/pkg/rtcconfig/ip.go
+++ b/pkg/rtcconfig/ip.go
@@ -118,6 +118,7 @@ func findExternalIP(ctx context.Context, stunServer string, localAddr net.Addr) 
 	if err != nil {
 		return "", err
 	}
+	defer c.Close()
 
 	message, err := stun.Build(stun.TransactionID, stun.BindingRequest)
 	if err != nil {


### PR DESCRIPTION
To prevent issues due to one provider not being able to reach STUN of another provider, try all STUN servers.