### PR TITLE
Add ICE candidate-pair acceptance min-wait parameters

### DIFF
--- a/pkg/rtcconfig/config.go
+++ b/pkg/rtcconfig/config.go
@@ -67,6 +67,12 @@ type RTCConfig struct {
 	SCTPFastRtxWnd int `yaml:"sctp_fast_rtx_wnd,omitempty"`
 	SCTPCwndCAStep int `yaml:"sctp_cwnd_ca_step,omitempty"`
 
+	// ICE candidate-pair acceptance min-waits; 0 keeps pion's default
+	HostAcceptanceMinWait  time.Duration `yaml:"host_acceptance_min_wait,omitempty"`
+	SrflxAcceptanceMinWait time.Duration `yaml:"srflx_acceptance_min_wait,omitempty"`
+	PrflxAcceptanceMinWait time.Duration `yaml:"prflx_acceptance_min_wait,omitempty"`
+	RelayAcceptanceMinWait time.Duration `yaml:"relay_acceptance_min_wait,omitempty"`
+
 	// for testing, disable UDP
 	ForceTCP bool `yaml:"force_tcp,omitempty"`
 }

--- a/pkg/rtcconfig/webrtc_config.go
+++ b/pkg/rtcconfig/webrtc_config.go
@@ -202,6 +202,19 @@ func NewWebRTCConfig(rtcConf *RTCConfig, development bool) (*WebRTCConfig, error
 	}
 	s.SetNetworkTypes(networkTypes)
 
+	if rtcConf.HostAcceptanceMinWait > 0 {
+		s.SetHostAcceptanceMinWait(rtcConf.HostAcceptanceMinWait)
+	}
+	if rtcConf.SrflxAcceptanceMinWait > 0 {
+		s.SetSrflxAcceptanceMinWait(rtcConf.SrflxAcceptanceMinWait)
+	}
+	if rtcConf.PrflxAcceptanceMinWait > 0 {
+		s.SetPrflxAcceptanceMinWait(rtcConf.PrflxAcceptanceMinWait)
+	}
+	if rtcConf.RelayAcceptanceMinWait > 0 {
+		s.SetRelayAcceptanceMinWait(rtcConf.RelayAcceptanceMinWait)
+	}
+
 	if rtcConf.EnableLoopbackCandidate {
 		s.SetIncludeLoopbackCandidate(true)
 	}


### PR DESCRIPTION
Forwards pion's host/srflx/prflx/relay `AcceptanceMinWait` to the `SettingEngine` via `rtc.*` config, guarded by `> 0` like the existing `sctp_*` params — unset/0 keeps pion's current defaults.

Lowering `prflx_acceptance_min_wait` removes a fixed ~1s connect delay for server-side SDK participants co-located with the SFU (no NAT): their first connectivity check can reach the server before their trickled host candidate, forming a peer-reflexive pair that can't be nominated until `prflxAcceptanceMinWait` (1s default). Repro'd with `@livekit/rtc-node` (~1100ms → ~82ms); the Go SDK trickles host-first and is unaffected.
