### PR TITLE
rtcconfig: respect AdvertiseInternalIP when node_ip is set manually

### DIFF
--- a/pkg/rtcconfig/webrtc_config.go
+++ b/pkg/rtcconfig/webrtc_config.go
@@ -264,9 +264,19 @@ func NewWebRTCConfig(rtcConf *RTCConfig, development bool) (*WebRTCConfig, error
 }
 
 func SetNAT1To1AddressRewriteRules(s *webrtc.SettingEngine, ips []string, includeInternal bool) error {
+	return s.SetICEAddressRewriteRules(nat1To1AddressRewriteRules(ips, includeInternal)...)
+}
+
+func nat1To1AddressRewriteRules(ips []string, includeInternal bool) []webrtc.ICEAddressRewriteRule {
 	rules := make([]webrtc.ICEAddressRewriteRule, 0, len(ips)+1)
 	catchAll := make([]string, 0, len(ips))
 
+	// Leaving Mode unspecified makes pion/webrtc fall back to its own default
+	// for the candidate type, which is Replace for host candidates — the same
+	// as explicitly requesting includeInternal=false. So catchAll must carry
+	// the resolved mode explicitly too, or includeInternal=true silently has
+	// no effect for plain IPs (the common case: NodeIP.ToStringSlice() and
+	// bare external IPs never contain "/" and always land here).
 	mode := webrtc.ICEAddressRewriteModeUnspecified
 	if includeInternal {
 		mode = webrtc.ICEAddressRewriteAppend
@@ -287,10 +297,11 @@ func SetNAT1To1AddressRewriteRules(s *webrtc.SettingEngine, ips []string, includ
 		rules = append(rules, webrtc.ICEAddressRewriteRule{
 			External:        catchAll,
 			AsCandidateType: webrtc.ICECandidateTypeHost,
+			Mode:            mode,
 		})
 	}
 
-	return s.SetICEAddressRewriteRules(rules...)
+	return rules
 }
 
 func iceServerForStunServers(servers []string) webrtc.ICEServer {

--- a/pkg/rtcconfig/webrtc_config.go
+++ b/pkg/rtcconfig/webrtc_config.go
@@ -109,19 +109,6 @@ func NewWebRTCConfig(rtcConf *RTCConfig, development bool) (*WebRTCConfig, error
 			}
 			nat1to1IPs = ips
 		} else {
-			// AdvertiseInternalIP previously wasn't threaded through here, so
-			// setting rtc.node_ip manually (use_external_ip: false) always
-			// REPLACED host candidates with node_ip instead of keeping the
-			// original alongside it (pion/webrtc: NAT1-to-1 rewrite with
-			// Mode unspecified defaults to Replace for host candidates;
-			// ICEAddressRewriteAppend keeps both). That's fine when node_ip
-			// is reachable from everywhere, but breaks same-network peers
-			// when node_ip is only reachable from outside (e.g. a node
-			// behind a NAT/load balancer that isn't itself reachable via
-			// that address) — those peers lose their only working
-			// candidate. AdvertiseInternalIP already exists in config
-			// specifically to avoid this; it just wasn't respected in this
-			// branch.
 			logger.Infow("using explicit node IP for NAT1To1Ips", "ip", rtcConf.NodeIP, "advertiseInternalIP", rtcConf.AdvertiseInternalIP)
 			if err := SetNAT1To1AddressRewriteRules(&s, rtcConf.NodeIP.ToStringSlice(), rtcConf.AdvertiseInternalIP); err != nil {
 				return nil, err
@@ -271,12 +258,6 @@ func nat1To1AddressRewriteRules(ips []string, includeInternal bool) []webrtc.ICE
 	rules := make([]webrtc.ICEAddressRewriteRule, 0, len(ips)+1)
 	catchAll := make([]string, 0, len(ips))
 
-	// Leaving Mode unspecified makes pion/webrtc fall back to its own default
-	// for the candidate type, which is Replace for host candidates — the same
-	// as explicitly requesting includeInternal=false. So catchAll must carry
-	// the resolved mode explicitly too, or includeInternal=true silently has
-	// no effect for plain IPs (the common case: NodeIP.ToStringSlice() and
-	// bare external IPs never contain "/" and always land here).
 	mode := webrtc.ICEAddressRewriteModeUnspecified
 	if includeInternal {
 		mode = webrtc.ICEAddressRewriteAppend

--- a/pkg/rtcconfig/webrtc_config.go
+++ b/pkg/rtcconfig/webrtc_config.go
@@ -97,8 +97,8 @@ func NewWebRTCConfig(rtcConf *RTCConfig, development bool) (*WebRTCConfig, error
 			ipFilter = newFilter
 			s.SetIPFilter(ipFilter)
 			if len(ips) == 0 {
-				logger.Infow("no external IPs found, using node IP for NAT1To1Ips", "ip", rtcConf.NodeIP)
-				if err := SetNAT1To1AddressRewriteRules(&s, rtcConf.NodeIP.ToStringSlice(), false); err != nil {
+				logger.Infow("no external IPs found, using node IP for NAT1To1Ips", "ip", rtcConf.NodeIP, "advertiseInternalIP", rtcConf.AdvertiseInternalIP)
+				if err := SetNAT1To1AddressRewriteRules(&s, rtcConf.NodeIP.ToStringSlice(), rtcConf.AdvertiseInternalIP); err != nil {
 					return nil, err
 				}
 			} else {
@@ -109,7 +109,21 @@ func NewWebRTCConfig(rtcConf *RTCConfig, development bool) (*WebRTCConfig, error
 			}
 			nat1to1IPs = ips
 		} else {
-			if err := SetNAT1To1AddressRewriteRules(&s, rtcConf.NodeIP.ToStringSlice(), false); err != nil {
+			// AdvertiseInternalIP previously wasn't threaded through here, so
+			// setting rtc.node_ip manually (use_external_ip: false) always
+			// REPLACED host candidates with node_ip instead of keeping the
+			// original alongside it (pion/webrtc: NAT1-to-1 rewrite with
+			// Mode unspecified defaults to Replace for host candidates;
+			// ICEAddressRewriteAppend keeps both). That's fine when node_ip
+			// is reachable from everywhere, but breaks same-network peers
+			// when node_ip is only reachable from outside (e.g. a node
+			// behind a NAT/load balancer that isn't itself reachable via
+			// that address) — those peers lose their only working
+			// candidate. AdvertiseInternalIP already exists in config
+			// specifically to avoid this; it just wasn't respected in this
+			// branch.
+			logger.Infow("using explicit node IP for NAT1To1Ips", "ip", rtcConf.NodeIP, "advertiseInternalIP", rtcConf.AdvertiseInternalIP)
+			if err := SetNAT1To1AddressRewriteRules(&s, rtcConf.NodeIP.ToStringSlice(), rtcConf.AdvertiseInternalIP); err != nil {
 				return nil, err
 			}
 		}

--- a/pkg/rtcconfig/webrtc_config_test.go
+++ b/pkg/rtcconfig/webrtc_config_test.go
@@ -89,10 +89,6 @@ func Test_InterfaceFilterFromConf(t *testing.T) {
 }
 
 func Test_NAT1To1AddressRewriteRules(t *testing.T) {
-	// Plain IPs (no "external/local" pair) fall into the catchAll rule.
-	// Its Mode must track includeInternal just like the per-IP rules do,
-	// otherwise it silently keeps pion/webrtc's default for host candidates
-	// (Replace) regardless of includeInternal.
 	t.Run("catchAll replaces host candidate when includeInternal is false", func(t *testing.T) {
 		rules := nat1To1AddressRewriteRules([]string{"1.2.3.4"}, false)
 		require.Len(t, rules, 1)

--- a/pkg/rtcconfig/webrtc_config_test.go
+++ b/pkg/rtcconfig/webrtc_config_test.go
@@ -18,6 +18,7 @@ import (
 	"net"
 	"testing"
 
+	"github.com/pion/webrtc/v4"
 	"github.com/stretchr/testify/require"
 )
 
@@ -85,4 +86,38 @@ func Test_InterfaceFilterFromConf(t *testing.T) {
 			t.Errorf("For interface %s, expected %v but got %v", tc.iface, tc.expected, result)
 		}
 	}
+}
+
+func Test_NAT1To1AddressRewriteRules(t *testing.T) {
+	// Plain IPs (no "external/local" pair) fall into the catchAll rule.
+	// Its Mode must track includeInternal just like the per-IP rules do,
+	// otherwise it silently keeps pion/webrtc's default for host candidates
+	// (Replace) regardless of includeInternal.
+	t.Run("catchAll replaces host candidate when includeInternal is false", func(t *testing.T) {
+		rules := nat1To1AddressRewriteRules([]string{"1.2.3.4"}, false)
+		require.Len(t, rules, 1)
+		require.Equal(t, []string{"1.2.3.4"}, rules[0].External)
+		require.Equal(t, webrtc.ICECandidateTypeHost, rules[0].AsCandidateType)
+		require.Equal(t, webrtc.ICEAddressRewriteModeUnspecified, rules[0].Mode)
+	})
+
+	t.Run("catchAll appends host candidate when includeInternal is true", func(t *testing.T) {
+		rules := nat1To1AddressRewriteRules([]string{"1.2.3.4"}, true)
+		require.Len(t, rules, 1)
+		require.Equal(t, []string{"1.2.3.4"}, rules[0].External)
+		require.Equal(t, webrtc.ICECandidateTypeHost, rules[0].AsCandidateType)
+		require.Equal(t, webrtc.ICEAddressRewriteAppend, rules[0].Mode)
+	})
+
+	t.Run("external/local pairs and catchAll IPs get the same mode", func(t *testing.T) {
+		rules := nat1To1AddressRewriteRules([]string{"5.6.7.8/10.0.0.1", "1.2.3.4"}, true)
+		require.Len(t, rules, 2)
+
+		require.Equal(t, []string{"5.6.7.8"}, rules[0].External)
+		require.Equal(t, "10.0.0.1", rules[0].Local)
+		require.Equal(t, webrtc.ICEAddressRewriteAppend, rules[0].Mode)
+
+		require.Equal(t, []string{"1.2.3.4"}, rules[1].External)
+		require.Equal(t, webrtc.ICEAddressRewriteAppend, rules[1].Mode)
+	})
 }


### PR DESCRIPTION
 SetNAT1To1AddressRewriteRules was always called with includeInternal
  hardcoded to false in the branch taken when NodeIP is explicitly
  configured and UseExternalIP is false — AdvertiseInternalIP was read
  from config but never passed through, so it had no effect in this
  code path.

  With includeInternal=false, pion/webrtc's NAT1-to-1 rewrite defaults
  to Mode: Replace for host candidates, dropping the original local
  candidate in favor of the rewritten one. That's fine when node_ip is
  reachable from every peer, but breaks peers on the same network as
  the host when node_ip is only reachable from *outside* it (e.g. the
  host sits behind a NAT/load balancer that isn't itself reachable via
  that address from inside its own network) — those peers lose their
  only working candidate, since the replacement one is unreachable to
  them specifically.

  AdvertiseInternalIP already exists in RTCConfig for exactly this
  case (switches the rewrite to Mode: Append, keeping both candidates)
  and is already respected in the sibling branch (UseExternalIP=true
  with discovered IPs) — this just extends it to the explicit-node_ip
  branch instead of hardcoding false.

  Also applies the same fix to the len(ips)==0 fallback within the
  UseExternalIP=true branch, which had the identical hardcoded false.